### PR TITLE
updated history and exclamation point docs

### DIFF
--- a/gosh/gosh.go
+++ b/gosh/gosh.go
@@ -9,20 +9,21 @@ import (
 )
 
 var (
-	//list that will hold all commands typed in the terminal
+	// list that will hold all commands typed in the terminal
 	commandList []string
 
-	//tmpfile will hold a command queried by the "!" character
-	//oldStdin will remember the traditional Stdin when it is
-	//switched to tmpfile (see 'exclamation.go')
-	//checker is a flag that will signal code in 'getInput()'
-	//to run if "!" is used
+	// tmpfile will hold a command queried by the "!" character.
+	// oldStdin will remember the traditional Stdin when it is
+	// switched to tmpfile (see 'exclamation.go').
+	// Checker is a flag that will "activate" code in 'getInput()'
+	// to run if "!" is used.
 	tmpfile  *os.File
 	oldStdin *os.File = os.Stdin
 	checker  bool     = false
 
-	// will save the position of latest command saved in
-	// command history file
+	// saves the position in commandHistory list where this session's
+	// commands start. That way, when the shell closes, we only copy this
+	// session's commands to the history file.
 	whereLeftOff int
 
 	// ComMap with be used to create a map of strings (command keys) to Commands (the functions)
@@ -41,7 +42,7 @@ type (
 )
 
 func main() {
-	// loads the command history file contents into RAM
+	// loads the command history file contents from gosh_history.tmp into RAM
 	loadHistory()
 	// Main loop
 	for {
@@ -80,7 +81,8 @@ func main() {
 
 // loads the contents of gosh_history.tmp into the commandList array
 func loadHistory() {
-	historyFile, _ := os.Open("gosh_history.tmp")
+	// open the gosh_history file for reading
+	historyFile, _ := os.OpenFile("gosh_history.tmp", os.O_RDONLY | os.O_CREATE | os.O_APPEND, 0755)
 	scanner := bufio.NewScanner(historyFile)
 	for scanner.Scan() {
 		// append the command from the gosh_history.tmp and remove the
@@ -94,9 +96,13 @@ func loadHistory() {
 
 func getInput() string {
 	var (
+		// line will hold the command
+		// e will hold any error messages for us to ignore
 		line string
 		e    error
 	)
+	// If checker is true, it means the exclamation command was run, so we need
+	// to run the command it saved to its temporary file. Therefore,
 	// temporarily change Stdin to the temporary file created in exclamation.go,
 	// read in its contents, and execute the result
 	if checker {
@@ -107,10 +113,10 @@ func getInput() string {
 	// Create a keyboard reader, which will either read from the keyboard
 	// or from the temporary file created in the exclamation.go
 	keyboard := bufio.NewReader(os.Stdin)
-	// Read a line of input from Stdin until carraige return
+	// Read a line of input from Stdin until carriage return
 	line, e = keyboard.ReadString('\n')
-	//if Stdin was changed, switch back to the original Stdin
-	//if it wasn't changed, oh well. Doing it this way makes for a cleaner
+	// if Stdin was changed, switch back to the original Stdin
+	// if it wasn't changed, oh well. Doing it this way makes for a cleaner
 	//code
 	os.Stdin = oldStdin
 	// Print out any errors
@@ -170,9 +176,11 @@ func execute(command Command) {
 	}
 }
 
+// when the shell is about to be closed, saved all this session's commands to the
+// gosh_history file.
 func saveHistory() {
 	// limit is one minus the length of commandList so to not include
-	// the exit command in the history
+	// any exit commands
 	limit := len(commandList) - 1
 	historyFile, _ := os.OpenFile("gosh_history.tmp", os.O_WRONLY|os.O_APPEND, 0)
 	// add only the commands executed during this session to the


### PR DESCRIPTION
This change not only contains documentation updates, but switches the instruction in loadHistory() from opening an existing "gosh_history.tmp" to checking if it exists, open for appending if it does, create it if it doesn't. I don't want anything to break, so that's why I pushed to a branch